### PR TITLE
[Feature] Add functionalities to CustomDataset Class

### DIFF
--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -82,16 +82,16 @@ public:
         cv::Mat* img_varray = new cv::Mat[batch_size*batch_size];
         cv::Mat out(256, 256, CV_8UC3);
         for(int i = 0; i < batch_size*batch_size; i++) {
-	    *(img_varray + i) = cv::Mat::eye(64, 64, CV_8UC3);
-	    torch::Tensor out_tensor = get(i).data.squeeze().detach().permute({1, 2, 0});
-	    out_tensor = out_tensor.to(torch::kU8);
-	    std::cout << out_tensor.sizes() << std::endl;
-	    std::memcpy((img_varray + i)->data, out_tensor.data_ptr(), sizeof(torch::kU8) * out_tensor.numel());
+            *(img_varray + i) = cv::Mat::eye(64, 64, CV_8UC3);
+            torch::Tensor out_tensor = get(i).data.squeeze().detach().permute({1, 2, 0});
+            out_tensor = out_tensor.to(torch::kU8);
+            std::cout << out_tensor.sizes() << std::endl;
+            std::memcpy((img_varray + i)->data, out_tensor.data_ptr(), sizeof(torch::kU8) * out_tensor.numel());
         }
-	out = *(img_varray + 0);
+        out = *(img_varray + 0);
         for(int i = 0; i < batch_size * batch_size - 1; i++) {
-	    cv::hconcat(out, *(img_varray + i + 1), out);
-	}
+        cv::hconcat(out, *(img_varray + i + 1), out);
+    }
     // cv::hconcat(img_varray, 9, out);
     // Save the image as out.jpg
     cv::imwrite("out.jpg", out);

--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -92,9 +92,9 @@ public:
 
     // Visualizes sample at the given index
     void show_sample(int index) {
-        cv::Mat sample_img(64, 64, CV_8UC3);
         torch::Tensor out_tensor_ = get(index).data.squeeze().detach().permute({1, 2, 0});
         out_tensor_ = out_tensor_.clamp(0, 255).to(torch::kCPU).to(torch::kU8);
+        cv::Mat sample_img(out_tensor_.sizes()[0], out_tensor_.sizes()[1], CV_8UC3);
         std::memcpy(sample_img.data, out_tensor_.data_ptr(), sizeof(torch::kU8) * out_tensor_.numel());
         cv::imwrite("sample.jpg", sample_img);
         std::cout << "Image saved as sample.jpg" << std::endl;

--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -60,6 +60,36 @@ public:
         return {sample_img.clone(), sample_label.clone()};
     };
     
+    // cv::Mat show_batch(int batch_size = 3) {
+    //     /* 
+    //     Visualize batch of data (by default 3x3) 
+    //     */
+    //     // Declare img_array as a pointer
+    //     cv::Mat* img_varray;
+    //     for(int i = 0; i < batch_size; i++) {
+    //         *(img_varray + i) = get(i).at(0);
+    //     }
+    //     cv::Mat out;
+    //     cv::hconcat(img_varray, 3, out);
+    //     return out;
+    // }
+
+    void show_batch(int batch_size = 3) {
+        /* 
+        Visualize batch of data (by default 3x3) 
+        */
+        // Declare img_array as a pointer
+        cv::Mat* img_varray = nullptr;
+        for(int i = 0; i < batch_size; i++) {
+            std::memcpy((void*)get(i).data.data_ptr(), (void*)*(img_varray + i)->data, sizeof(float) * get(i).data.numel());
+        }
+        cv::Mat out;
+        cv::hconcat(img_varray, 3, out);
+        // Save the image as out.jpg
+        cv::imwrite("out.jpg", out);
+        std::cout << "Image saved as out.jpg" << std::endl;
+    }
+
     torch::optional<size_t> size() const override {
         return int(ds_size);
     };

--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -68,9 +68,7 @@ public:
         for(int i = 0; i < batch_size*batch_size; i++) {
             *(img_varray + i) = cv::Mat::eye(64, 64, CV_8UC3);
             torch::Tensor out_tensor = get(i).data.squeeze().detach().permute({1, 2, 0});
-            out_tensor = out_tensor.clamp(0, 255);
-            out_tensor = out_tensor.to(torch::kCPU);
-            out_tensor = out_tensor.to(torch::kU8);
+            out_tensor = out_tensor.clamp(0, 255).to(torch::kCPU).to(torch::kU8);
             std::memcpy((img_varray + i)->data, out_tensor.data_ptr(), sizeof(torch::kU8) * out_tensor.numel());
         }
         cv::Mat out(256, 256, CV_8UC3); // TODO: Set channel according to the dataset, instead of manual
@@ -90,6 +88,15 @@ public:
         cv::cvtColor(temp_out, temp_out, cv::COLOR_BGR2RGB);
         cv::imwrite("out.jpg", temp_out);
         std::cout << "Image saved as out.jpg" << std::endl;
+    }
+
+    void show_sample(int index) {
+        cv::Mat sample_img(64, 64, CV_8UC3);
+        torch::Tensor out_tensor_ = get(index).data.squeeze().detach().permute({1, 2, 0});
+        out_tensor_ = out_tensor_.clamp(0, 255).to(torch::kCPU).to(torch::kU8);
+        std::memcpy(sample_img.data, out_tensor_.data_ptr(), sizeof(torch::kU8) * out_tensor_.numel());
+        cv::imwrite("sample.jpg", sample_img);
+        std::cout << "Image saved as sample.jpg" << std::endl;
     }
 
     torch::optional<size_t> size() const override {

--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -18,7 +18,8 @@
 // Function to return image read at location given as type torch::Tensor
 torch::Tensor read_data(std::string location, int resize);
 
-// Function to return label from int (0, 1 for binary and 0, 1, ..., n-1 for n-class classification) as type torch::Tensor
+// Function to return label from int (0, 1 for binary and 0, 1, ..., n-1 for n-class classification) as type 
+// torch::Tensor
 torch::Tensor read_label(int label);
 
 // Function returns vector of tensors (images) read from the list of images in a folder
@@ -33,7 +34,8 @@ std::pair<std::vector<std::string>, std::vector<int>> load_data_from_folder(std:
 
 // Function to train the network on train data
 template<typename Dataloader>
-void train(torch::jit::script::Module net, torch::nn::Linear lin, Dataloader& data_loader, torch::optim::Optimizer& optimizer, size_t dataset_size);
+void train(torch::jit::script::Module net, torch::nn::Linear lin, Dataloader& data_loader, \
+torch::optim::Optimizer& optimizer, size_t dataset_size);
 
 // Function to test the network on test data
 template<typename Dataloader>
@@ -60,18 +62,16 @@ public:
         return {sample_img.clone(), sample_label.clone()};
     };
 
+    // Visualize batch of data (by default 3x3)
     void show_batch(int batch_size = 3) {
-        /* 
-        Visualize batch of data (by default 3x3) 
-        */
         cv::Mat* img_varray = new cv::Mat[batch_size*batch_size];
         for(int i = 0; i < batch_size*batch_size; i++) {
-            *(img_varray + i) = cv::Mat::eye(64, 64, CV_8UC3);
             torch::Tensor out_tensor = get(i).data.squeeze().detach().permute({1, 2, 0});
             out_tensor = out_tensor.clamp(0, 255).to(torch::kCPU).to(torch::kU8);
+            *(img_varray + i) = cv::Mat::eye(out_tensor.sizes()[0], out_tensor.sizes()[1], CV_8UC3);
             std::memcpy((img_varray + i)->data, out_tensor.data_ptr(), sizeof(torch::kU8) * out_tensor.numel());
         }
-        cv::Mat out(256, 256, CV_8UC3); // TODO: Set channel according to the dataset, instead of manual
+        cv::Mat out(256, 256, CV_8UC3);
         cv::Mat temp_out(256, 256, CV_8UC3);
         for(int vconcat_times = 0; vconcat_times < batch_size; vconcat_times++) {
             cv::cvtColor(*(img_varray + vconcat_times*batch_size), out, cv::COLOR_BGR2RGB);
@@ -90,6 +90,7 @@ public:
         std::cout << "Image saved as out.jpg" << std::endl;
     }
 
+    // Visualizes sample at the given index
     void show_sample(int index) {
         cv::Mat sample_img(64, 64, CV_8UC3);
         torch::Tensor out_tensor_ = get(index).data.squeeze().detach().permute({1, 2, 0});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,8 +56,11 @@ int main(int argc, const char * argv[]) {
   std::vector<std::string> list_images = pair_images_labels.first;
   std::vector<int> list_labels = pair_images_labels.second;
 
+  auto custom_dataset2 = CustomDataset(list_images, list_labels, 64);
+  custom_dataset2.show_batch();
   // Originally 224 size, resize to 64 instead 
   auto custom_dataset = CustomDataset(list_images, list_labels, 64).map(torch::data::transforms::Normalize<>(0.5, 0.5)).map(torch::data::transforms::Stack<>());
+  // custom_dataset.show_batch();
 
   auto data_loader = torch::data::make_data_loader<torch::data::samplers::RandomSampler>(std::move(custom_dataset), torch::data::DataLoaderOptions().batch_size(args.batch_size).workers(2));
 
@@ -67,7 +70,7 @@ int main(int argc, const char * argv[]) {
   }
 
   std::cout << "Using device: " << device << std::endl; 
-  Generator G = Generator(/*nc_=3*/, /*nz_=*/300, /*ngf_=*/64);
+  Generator G = Generator(/*nc_=*/3, /*nz_=*/300, /*ngf_=*/64);
   Discriminator D = Discriminator(/*nc_=*/3, /*ndf_=*/64);
 
   torch::nn::Sequential netG = G.get_module();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,8 @@ int ngf = 64;
 int ndf = 64;
 
 int main(int argc, const char * argv[]) {
-  Arguments args = Arguments("/home/kshrimali/Documents/DCGAN-cuda/dcgan-libtorch/data", 2, 64, 64, 3, 300, 64, 64, 5, 0.001, 0.5, 1);
-  std::string images_name = args.dataroot + "/test";
+  Arguments args = Arguments("/home/ubuntu/dcgan/celebA/test", 2, 64, 64, 3, 300, 64, 64, 5, 0.001, 0.5, 1);
+  std::string images_name = args.dataroot + "/img_align_celeba/";
 
   std::vector<std::string> folders_name;
   folders_name.push_back(images_name);
@@ -56,11 +56,13 @@ int main(int argc, const char * argv[]) {
   std::vector<std::string> list_images = pair_images_labels.first;
   std::vector<int> list_labels = pair_images_labels.second;
 
-  auto custom_dataset2 = CustomDataset(list_images, list_labels, 64);
-  custom_dataset2.show_batch();
+  // auto custom_dataset2 = CustomDataset(list_images, list_labels, 64);
+  // custom_dataset2.show_batch(4);
   // Originally 224 size, resize to 64 instead 
-  auto custom_dataset = CustomDataset(list_images, list_labels, 64).map(torch::data::transforms::Normalize<>(0.5, 0.5)).map(torch::data::transforms::Stack<>());
-  // custom_dataset.show_batch();
+  auto custom_dataset_init = CustomDataset(list_images, list_labels, 64);
+  custom_dataset_init.show_batch(5);
+  custom_dataset_init.show_sample(5);
+  auto custom_dataset = custom_dataset_init.map(torch::data::transforms::Normalize<>(0.5, 0.5)).map(torch::data::transforms::Stack<>());
 
   auto data_loader = torch::data::make_data_loader<torch::data::samplers::RandomSampler>(std::move(custom_dataset), torch::data::DataLoaderOptions().batch_size(args.batch_size).workers(2));
 


### PR DESCRIPTION
- [x] Add `show_batch()` method to `CustomDataset` class (which visualises sample batch of data set)
    - [x] Add `show_batch()` method
    - [x] ~~Use Random Images to visualise the data set~~
- [x] Add `show_sample(index)` method to `CustomDataset` class (to visualise `tensor.at<index>`)
- [x] ~~Add generalised `train()` function, add options for `save_checkpoint, load_checkpoint, save_losses, plot_loss_graph` etc.~~

Using Random Indexes to visualise a batch is still under review. I'm not sure if it's worth all the efforts. Sequential indexing for batch visualisation still works fine! Adding a generalised `train` function is not a necessity for now, and will be added in future PRs. 

Added functionalities to visualise batch and sample can be used as:
```
auto dataset = CustomDataset(list_images, list_labels, 64);
dataset.show_batch(5); // create a 5x5 grid to visualise initial 25 images of the data set
dataset.show_sample(4); // visualise 4th image in the data set
```
This PR solves #2. 