### PR TITLE
Change C style comments to C++ style comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ This is the output from random noise (batch of) images after ~10 epochs of train
 <img src="images/dcgan-output.png"/>
 
 Happy learning!
+
+# TODOs
+
+// Add TODOs here

--- a/src/dataset.cpp
+++ b/src/dataset.cpp
@@ -8,19 +8,17 @@
 
 #include "dataset.hpp"
 
+// Function to return image read at location given as type torch::Tensor
+// Resizes image to (224, 224, 3)
+// Parameters
+// ===========
+// 1. location (std::string type) - required to load image from the location
+// 2. resize (int type) - required to resize an image
+//
+// Returns
+// ===========
+// torch::Tensor type - image read as tensor
 torch::Tensor read_data(std::string location, int resize=224) {
-    /*
-     Function to return image read at location given as type torch::Tensor
-     Resizes image to (224, 224, 3)
-     Parameters
-     ===========
-     1. location (std::string type) - required to load image from the location
-     2. resize (int type) - required to resize an image
- 
-     Returns
-     ===========
-     torch::Tensor type - image read as tensor
-     */
     cv::Mat img = cv::imread(location, 1);
     cv::resize(img, img, cv::Size(resize, resize), cv::INTER_CUBIC);
     torch::Tensor img_tensor = torch::from_blob(img.data, {img.rows, img.cols, 3}, torch::kByte);
@@ -28,33 +26,30 @@ torch::Tensor read_data(std::string location, int resize=224) {
     return img_tensor.clone();
 }
 
+// Function to return label from int (0, 1 for binary and 0, 1, ..., n-1 for n-class classification) as type torch::Tensor
+// Parameters
+// ===========
+// 1. label (int type) - required to convert int to tensor
+//
+// Returns
+// ===========
+// torch::Tensor type - label read as tensor
 torch::Tensor read_label(int label) {
-    /*
-     Function to return label from int (0, 1 for binary and 0, 1, ..., n-1 for n-class classification) as type torch::Tensor
-     Parameters
-     ===========
-     1. label (int type) - required to convert int to tensor
-     
-     Returns
-     ===========
-     torch::Tensor type - label read as tensor
-     */
     torch::Tensor label_tensor = torch::full({1}, label);
     return label_tensor.clone();
 }
 
+//
+// Function returns vector of tensors (images) read from the list of images in a folder
+// Parameters
+// ===========
+// 1. list_images (std::vector<std::string> type) - list of image paths in a folder to be read
+// 2. resize (int type) - argument for resizing each image
+//
+// Returns
+// ===========
+// std::vector<torch::Tensor> type - Images read as tensors
 std::vector<torch::Tensor> process_images(std::vector<std::string> list_images, int resize=224) {
-    /*
-     Function returns vector of tensors (images) read from the list of images in a folder
-     Parameters
-     ===========
-     1. list_images (std::vector<std::string> type) - list of image paths in a folder to be read
-     2. resize (int type) - argument for resizing each image
- 
-     Returns
-     ===========
-     std::vector<torch::Tensor> type - Images read as tensors
-     */
     std::vector<torch::Tensor> states;
     for(auto it = list_images.begin(); it != list_images.end(); ++it) {
         torch::Tensor img = read_data(*it, resize);
@@ -63,17 +58,15 @@ std::vector<torch::Tensor> process_images(std::vector<std::string> list_images, 
     return states;
 }
 
+// Function returns vector of tensors (labels) read from the list of labels
+// Parameters
+// ===========
+// 1. list_labels (std::vector<int> list_labels) -
+//
+// Returns
+// ===========
+// std::vector<torch::Tensor> type - returns vector of tensors (labels)
 std::vector<torch::Tensor> process_labels(std::vector<int> list_labels) {
-    /*
-     Function returns vector of tensors (labels) read from the list of labels
-     Parameters
-     ===========
-     1. list_labels (std::vector<int> list_labels) -
-     
-     Returns
-     ===========
-     std::vector<torch::Tensor> type - returns vector of tensors (labels)
-     */
     std::vector<torch::Tensor> labels;
     for(auto it = list_labels.begin(); it != list_labels.end(); ++it) {
         torch::Tensor label = read_label(*it);
@@ -82,18 +75,16 @@ std::vector<torch::Tensor> process_labels(std::vector<int> list_labels) {
     return labels;
 }
 
+// Function to load data from given folder(s) name(s) (folders_name)
+// Returns pair of vectors of string (image locations) and int (respective labels)
+// Parameters
+// ===========
+// 1. folders_name (std::vector<std::string> type) - name of folders as a vector to load data from
+//
+// Returns
+// ===========
+// std::pair<std::vector<std::string>, std::vector<int>> type - returns pair of vector of strings (image paths) and respective labels' vector (int label)
 std::pair<std::vector<std::string>,std::vector<int>> load_data_from_folder(std::vector<std::string> folders_name) {
-    /*
-     Function to load data from given folder(s) name(s) (folders_name)
-     Returns pair of vectors of string (image locations) and int (respective labels)
-     Parameters
-     ===========
-     1. folders_name (std::vector<std::string> type) - name of folders as a vector to load data from
-     
-     Returns
-     ===========
-     std::pair<std::vector<std::string>, std::vector<int>> type - returns pair of vector of strings (image paths) and respective labels' vector (int label)
-     */
     std::vector<std::string> list_images;
     std::vector<int> list_labels;
 
@@ -126,5 +117,3 @@ std::pair<std::vector<std::string>,std::vector<int>> load_data_from_folder(std::
     }
     return std::make_pair(list_images, list_labels);
 }
-
-


### PR DESCRIPTION
This PR attempts to:

1. Change C style comments to C++ style comments in `src/dataset.cpp`. Also useful since current Doxygen configuration file only considers C++ style comments (`//`).
2. Migrate from in-body to outside-body:

```
// outside-body comments
void func() {
     // in-body comments
}
```